### PR TITLE
default to all dirs

### DIFF
--- a/src/clj_reload/core.clj
+++ b/src/clj_reload/core.clj
@@ -3,6 +3,7 @@
     [clj-reload.keep :as keep]
     [clj-reload.parse :as parse]
     [clj-reload.util :as util]
+    [clojure.java.classpath :as classpath]
     [clojure.java.io :as io]))
 
 ; State :: {// config
@@ -257,7 +258,11 @@
    (reload nil))
   ([opts]
    (binding [util/*log-fn* (:log-fn opts util/*log-fn*)]
-     (swap! *state scan opts)
+     (if (empty? @*state)
+       (do
+         (init {:dirs (classpath/classpath-directories)})
+         (swap! *state scan (assoc opts :only :all)))
+       (swap! *state scan opts))
      (loop [unloaded []
             loaded   []
             state    @*state]


### PR DESCRIPTION
This default means that a user does not have to init before running reload. But they can.

Mimics [tools.namespace behaviour](https://github.com/clojure/tools.namespace/blob/05328ed700840165bcf1c5d34d5ef2e299b58c1a/src/main/clojure/clojure/tools/namespace/dir.clj#L91).