### PR TITLE
Support custom file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next 
+
+- Added `:extensions` for custom file type extensions
+
 # 0.4.3 - Mar 21, 2024
 
 - Do not report self-reference as a cycle #6

--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ To support that, `clj-reload`:
 
 In that case, you can just call `clj-reload.core/reload` and it should work with default settings.
 
+## Usage: Reloading custom file types
+
+If you have custom file types, like `.repl`, you can specify that `clj-reload` should scan and reload them too:
+
+```clojure
+(reload/init
+  {:dirs [...]
+   :extensions #".*\.(?:cljc?|repl)"})
+```
+
 ## Comparison: Evaluating buffer
 
 The simplest way to reload Clojure code is just re-evaluating an entire buffer.

--- a/fixtures/core_test/custom_file_type.repl
+++ b/fixtures/core_test/custom_file_type.repl
@@ -1,0 +1,1 @@
+(ns custom-file-type)

--- a/test/clj_reload/parse_test.clj
+++ b/test/clj_reload/parse_test.clj
@@ -106,7 +106,7 @@ Unexpected :require form: [789 a b c]
 (deftest scan-impl-test
   (let [{files :files'
          nses  :namespaces'} (binding [util/*log-fn* nil]
-                               (@#'reload/scan-impl nil ["fixtures"] 0))]
+                               (@#'reload/scan-impl nil ["fixtures"] #".*\.cljc?" 0))]
     (testing "no-ns"
       (is (= '#{}
             (get-in files [(io/file "fixtures/core_test/no_ns.clj") :namespaces]))))
@@ -148,4 +148,13 @@ Unexpected :require form: [789 a b c]
             (get-in nses ['double :requires])))
 
       (is (= #{(io/file "fixtures/core_test/double.clj") (io/file "fixtures/core_test/double_b.clj")}
-            (get-in nses ['double :ns-files]))))))
+            (get-in nses ['double :ns-files]))))
+
+    (testing "custom-file-types"
+      (let [custom-file-type-re #".*\.(?:cljc?|repl)"
+            {files-custom :files'} (binding [util/*log-fn* nil]
+                                     (@#'reload/scan-impl nil ["fixtures"] custom-file-type-re 0))]
+        (is (nil?
+              (get-in files [(io/file "fixtures/core_test/custom_file_type.repl") :namespaces])))
+        (is (= '#{custom-file-type}
+              (get-in files-custom [(io/file "fixtures/core_test/custom_file_type.repl") :namespaces])))))))


### PR DESCRIPTION
We have `.repl` files that also needs to be `clj-reload`-ed. 

This adds the optional config: `:extensions #".*\.(?:cljc?|repl)`"