### PR TITLE
Implement reload-all by regex

### DIFF
--- a/fixtures/core_test/a.clj
+++ b/fixtures/core_test/a.clj
@@ -5,4 +5,6 @@
     d
     [z :as-alias z])
   (:import
-    [java.io File]))
+   [java.io File]))
+
+(def a nil)

--- a/fixtures/core_test/b.clj
+++ b/fixtures/core_test/b.clj
@@ -1,1 +1,3 @@
 (ns b)
+
+(def b nil)

--- a/fixtures/core_test/c.clj
+++ b/fixtures/core_test/c.clj
@@ -1,2 +1,4 @@
 (ns c
   (:require e))
+
+(def c nil)

--- a/fixtures/core_test/d.clj
+++ b/fixtures/core_test/d.clj
@@ -1,2 +1,4 @@
 (ns d
   (:require e))
+
+(def d nil)

--- a/fixtures/core_test/e.clj
+++ b/fixtures/core_test/e.clj
@@ -1,1 +1,3 @@
 (ns e)
+
+(def e nil)

--- a/fixtures/core_test/f.clj
+++ b/fixtures/core_test/f.clj
@@ -1,2 +1,4 @@
 (ns f
   (:require d g))
+
+(def f nil)

--- a/fixtures/core_test/g.clj
+++ b/fixtures/core_test/g.clj
@@ -1,1 +1,3 @@
 (ns g)
+
+(def g nil)

--- a/fixtures/core_test/h.clj
+++ b/fixtures/core_test/h.clj
@@ -1,2 +1,4 @@
 (ns h
   (:require e))
+
+(def h nil)

--- a/fixtures/core_test/i.clj
+++ b/fixtures/core_test/i.clj
@@ -1,2 +1,4 @@
 (ns i
   (:require j))
+
+(def i nil)

--- a/fixtures/core_test/j.clj
+++ b/fixtures/core_test/j.clj
@@ -1,2 +1,4 @@
 (ns j
   (:require k))
+
+(def j nil)

--- a/fixtures/core_test/k.clj
+++ b/fixtures/core_test/k.clj
@@ -1,1 +1,3 @@
 (ns k)
+
+(def k nil)

--- a/fixtures/core_test/l.clj
+++ b/fixtures/core_test/l.clj
@@ -1,1 +1,3 @@
 (ns l)
+
+(def l nil)

--- a/src/clj_reload/keep.clj
+++ b/src/clj_reload/keep.clj
@@ -175,15 +175,15 @@
         (keep-patch ns sym keep)))))
 
 (defn ns-load-patched [ns ^File file keeps]
-  (try    
+  (try
     (let [content (patch-file (slurp file) (patch-fn ns keeps))]
-      (util/ns-load-file content ns file))
-    
-    ;; check 
+      (util/ns-load-file content ns (.getName file)))
+
+    ;; check
     (@#'clojure.core/throw-if (not (find-ns ns))
       "namespace '%s' not found after loading '%s'"
       ns (.getPath file))
-      
+
     (finally
       ;; drop everything in stash
       (remove-ns 'clj-reload.stash)

--- a/src/clj_reload/util.clj
+++ b/src/clj_reload/util.clj
@@ -118,10 +118,10 @@
   (LineNumberingPushbackReader.
     (StringReader. s)))
 
-(defn ns-load-file [content ns ^File file]
-  (let [[_ ext] (re-matches #".*\.([^.]+)" (.getName file))
+(defn ns-load-file [content ns file-name]
+  (let [[_ ext] (re-matches #".*\.([^.]+)" file-name)
         path    (-> ns str (str/replace #"\-" "_") (str/replace #"\." "/") (str "." ext))]
-    (Compiler/load (StringReader. content) path (.getName file))))
+    (Compiler/load (StringReader. content) path file-name)))
 
 (defn loader-classpath []
   (->> (clojure.lang.RT/baseLoader)

--- a/test/clj_reload/core_test.clj
+++ b/test/clj_reload/core_test.clj
@@ -59,6 +59,28 @@
     (is (= '["Unloading" i f a j h d c l k e "Loading" e k l c d h j a f i] (modify opts 'e 'k 'l)))
     (is (= '["Unloading" i f a j h d c l k g e b "Loading" b e g k l c d h j a f i] (modify opts 'a 'b 'c 'd 'e 'f 'g 'h 'i 'j 'k 'l)))))
 
+(deftest reload-all-regex-test
+  (let [*reloads (atom [])]
+    (apply tu/init '[b e c d h g a f k j i l])
+    (binding [util/*log-fn* (fn [& [x :as log-line]]
+                              (when (#{"Loading" "Unloading" } x)
+                                (swap! *reloads conj log-line)))]
+      (reload/reload-all #"^e$")
+      (is (= '[("Unloading" f)
+               ("Unloading" a)
+               ("Unloading" h)
+               ("Unloading" d)
+               ("Unloading" c)
+               ("Unloading" e)
+               ("Loading" e)
+               ("Loading" c)
+               ("Loading" d)
+               ("Loading" h)
+               ("Loading" a)
+               ("Loading" f)]
+
+             @*reloads)))))
+
 (deftest return-value-ok-test
   (tu/init 'a 'f 'h)
   (is (= {:unloaded '[]


### PR DESCRIPTION
First try to implement reload-all by regex as described in https://github.com/tonsky/clj-reload/issues/10

Per requirements on the issue this PR :

 - doesn't change much code
 - shouldn't change the perf of current functionality

The main thing here is `clj-reload/reload-all`. As mentioned in the docstring it will only reload already loaded namespaces that have at least one var. The one var limitation is because I don't know any other way of getting the files to all namespaces, but I also think this is not an important limitation since reloading a namespace with no vars isn't probably useful.

There are a couple of small changes to the existing code like :

- making `clj-reload.core/ns-load` work on resources urls as well as files.
- `clj-reload.parse/read-file` try catch on the implementation signature, so both sigs are covered
- make `clj-reload.util/ns-load-file` require only a file-name instead of a ^File object
- A bunch of tests namespaces now have a dummy var with the same ns name, for testing purposes

I don't expect this to be merged as is but we have something to start with.