### PR TITLE
Keep read files in state to avoid reading stuff we know hasn't changed

### DIFF
--- a/test/clj_reload/parse_test.clj
+++ b/test/clj_reload/parse_test.clj
@@ -108,7 +108,7 @@ Unexpected :require form: [789 a b c]
          nses  :namespaces'} (binding [reload/*config* {:dirs ["fixtures"]
                                                         :files #".*\.cljc?"}
                                        util/*log-fn*  nil]
-                               (@#'reload/scan-impl nil 0))]
+                               (@#'reload/scan-impl {} nil 0))]
     (testing "no-ns"
       (is (= '#{}
             (get-in files [(io/file "fixtures/core_test/no_ns.clj") :namespaces]))))
@@ -156,7 +156,7 @@ Unexpected :require form: [789 a b c]
       (let [{files-custom :files'} (binding [reload/*config* {:dirs  ["fixtures"]
                                                               :files #".*\.(?:cljc?|repl)"}
                                              util/*log-fn* nil]
-                                     (@#'reload/scan-impl nil 0))]
+                                     (@#'reload/scan-impl {} nil 0))]
         (is (nil?
               (get-in files [(io/file "fixtures/core_test/custom_file_type.repl") :namespaces])))
         (is (= '#{custom-file-type}


### PR DESCRIPTION
**Problem**

`clj-reload` reads and parses all files that are part of a project when running `reload` . On bigger projects (~14000 Clojure files), doing that work takes seconds and most of the time when reloading.

**Solution**

Do not read files that have not changed since the last reload. Instead keep the parsed structure of read files in memory and update it accordingly

**Results**

Before

```clojure
(time (clj-reload.core/reload))
Unloading financing-multi-services-tests-co.system.config
Loading financing-multi-services-tests-co.system.config
"Elapsed time: 2873.685666 msecs"
=>
{:unloaded [financing-multi-services-tests-co.system.config], :loaded [financing-multi-services-tests-co.system.config]}
```
After

```clojure
(time (clj-reload.core/reload))
Unloading financing-multi-services-tests-co.system.config
Loading financing-multi-services-tests-co.system.config
"Elapsed time: 524.882334 msecs"
=>
{:unloaded [financing-multi-services-tests-co.system.config], :loaded [financing-multi-services-tests-co.system.config]}
```