### PR TITLE
Throw IllegalStateException when running `unload` or `reload` before `init`

### DIFF
--- a/src/clj_reload/core.clj
+++ b/src/clj_reload/core.clj
@@ -307,6 +307,8 @@
    (unload nil))
   ([opts]
    (with-lock
+     (when (empty? *config*)
+       (throw (IllegalStateException. "clj-reload not initialized. Call `init` first")))
      (binding [util/*log-fn* (:log-fn opts util/*log-fn*)]
        (swap! *state scan opts)
        (when (= (:output *config*) :quieter)

--- a/test/clj_reload/core_test.clj
+++ b/test/clj_reload/core_test.clj
@@ -5,8 +5,7 @@
    [clj-reload.test-util :as tu]
    [clj-reload.util :as util]
    [clojure.java.io :as io]
-   [clojure.string :as str]
-   [clojure.test :refer [is are deftest testing use-fixtures]]))
+   [clojure.test :refer [is deftest use-fixtures]]))
 
 (defn reset []
   (tu/reset '[two-nses-second two-nses split o n no-unload m l i j k f a g h d c e double b]))
@@ -39,11 +38,13 @@
 ;       e        k     o
 
 (deftest find-namespaces-test
+  (tu/init)
   (is (= '#{a b c d double e err-runtime f g h i j k l m n no-reload no-unload o split two-nses two-nses-second} (reload/find-namespaces)))
   (is (= '#{a b c d e f g h i j k l m n o} (reload/find-namespaces #"\w")))
   (is (= '#{a b c} (reload/find-namespaces #"[abc]"))))
 
 (deftest reload-test
+  (is (thrown-with-msg? IllegalStateException #"clj-reload not initialized. Call `init` first" (tu/reload)))
   (let [opts {:require '[b e c d h g a f k j i l]}]
     (is (= '["Unloading" a "Loading" a] (modify opts 'a)))
     (is (= '["Unloading" a b "Loading" b a] (modify opts 'b)))
@@ -118,6 +119,7 @@
   (is (= '["Unloading" a d c e "Loading" e c d a] (modify {:require '[a]} 'e 'h 'g 'f 'k))))
 
 (deftest unload-test
+  (is (thrown-with-msg? IllegalStateException #"clj-reload not initialized. Call `init` first" (tu/unload)))
   (tu/init 'a 'f 'h)
   (tu/touch 'e)
   (tu/unload)

--- a/test/clj_reload/test_util.clj
+++ b/test/clj_reload/test_util.clj
@@ -19,6 +19,8 @@
 
 (defn reset [nses]
   (reset! *trace [])
+  (reset! @#'reload/*state {})
+  (alter-var-root #'reload/*config* (constantly {}))
   (let [now (util/now)]
     (reset! *time now)
     (doseq [file (next (file-seq (io/file *dir*)))


### PR DESCRIPTION
**Context**
When disabling the default `init` run when requiring `clj-reload`'s core namespace, it is possible to run `reload` or `unload` before `init`, this is not the intended way to use those fns, but there's no explicit handling of the situation so it leads to a NullPointerException.

**Proposal**
Explicitly handle the scenario by throwing an IllegalStateException with a descriptive message. 
